### PR TITLE
Code refactoring - map_manager.h

### DIFF
--- a/map_manager.h
+++ b/map_manager.h
@@ -1,18 +1,23 @@
-class MapManager : public singleton<MapManager>
+#pragma once
+
+class MapManager: public singleton<MapManager>
 {
-	private :
-	
-		std::map<DWORD, std::map<DWORD, DWORD>> maps = {
+	private:
+		std::map<const DWORD, std::list<const DWORD>> m_map_manager = {
 			{ 181, {} },
 			{ 182, {} },
 			{ 183, {} }
 		};
 		
-	public :
-		bool Initialize();
-		void Destroy();
-		void Enter(LPCHARACTER pChar);
-		bool IsPlayerIPInMap(LPCHARACTER pChar);
-		bool IsUniqueIPMap(DWORD map_index);
-};
+	public:
+		const bool      Initialize();
+		void            Clear();
+		void            Destroy();
 
+		void            Enter(const LPCHARACTER ch);
+		void            Disconnect(const LPCHARACTER ch);
+
+		const size_t    GetIPMapCount(const DWORD dwMapIndex);
+		const bool      IsPlayerIPInMap(const LPCHARACTER ch);
+		const bool      IsUniqueIPMap(const DWORD dwMapIndex);
+};


### PR DESCRIPTION
Your map have as value type a another std::map, for what? Since you store in key and value the same thing (player id), you should use std::list / std::vector or anything you want, but not a another std::map for no-reason if your key is same as value and no possible changes.
You insert all time for each login in a x map the player id, you don't check if already exist and then insert it (you could use std::find/std::map::find), you use make_pair for map and that means the key can't be duplicated, but this isn't a good practice to trying to insert 1000 times and nothing happen.
You check if map size is smaller or equal than 0, how can be a map size < 0? 
You declared a another map for iterating in a for-loop, you don't need to do that. std::map<DWORD, DWORD> map_players = [....];
You use map.at(...), if you use this you should use the std::out_of_range too, otherwise have no sense, because you already did a check before if exist mapIndex by map.count(index), so you can use directly operator std::map::operator[] instead of std::map::at.
You declared a std::string with no-reason for GetHostName() -> return a const char *, which you can use strcmp(str1, str2) instead of string.compare(str2).
Your key of map should be as constant, because you don't want to change it.
You should use also #pragma once for your header file (including: less code, avoidance of name clashes, and sometimes improvement in compilation speed.)
Also you should remove the pid of player after disconnect of the map, have no sense to remain.